### PR TITLE
Make theme a hugo module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 ### Hugo ###
-/public/
-/resources/_gen/
+public/
+resources
 # Don't ignore themes folder in your actual project .gitignore if using submodules!
 /themes/
 .hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Below are the current features of this theme. Features labeled *optional* or *fr
 * Series posts taxonomy with single posts that list all posts in the current series (optional)
 * Next/prev links at the end of single posts for subsections or series posts (if enabled)
 * Subsection support for posts with custom permalinks for clean SEO URLs (optional)
-* Mobile-responsive, collapsable JS menu with automatic submenu support based on menu config
+* Mobile-responsive, collapsible JS menu with automatic submenu support based on menu config
 
 ### Posts & Projects
 

--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -3,7 +3,6 @@ baseURL = 'https://www.example.com/' # Enter your full production URL
 languageCode = 'en-us' # Default
 timeZone = 'America/New_York' # IANA timezone https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 title = 'Example Site' # Site title used throughout site
-theme = 'hugo-liftoff' # Use this theme
 
 ### SEO, Analytics & 3rd-party
 enableRobotsTXT = true # To overwrite the theme's robots.txt, add your own in the /layouts/ directory
@@ -41,6 +40,12 @@ dataDir = 'data' # Default
 disableHugoGeneratorInject = false # Default
 disableLiveReload = false # Default
 
+# Use this theme as git submodule
+theme = 'hugo-liftoff'
+# Or, use this theme as hugo module
+# [module]
+# [[module.imports]]
+#     path = 'hugo-liftoff'
 
 [taxonomies]
     tag = 'tags'

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/wjh18/hugo-liftoff
+
+go 1.20


### PR DESCRIPTION
# Description

This PR turns the theme into a [hugo module](https://gohugo.io/hugo-modules/).
It also fixes a typo I spotted on the way.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
