### PR TITLE
layouts: image: use exact match

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -8,7 +8,7 @@
 <!-- get actual filename -->
 {{- $src = path.Base $src -}}
 <!-- check if it exists as a page resource -->
-{{- with (.Page.Resources.ByType "image").GetMatch (printf "%s" $src) -}}
+{{- with (.Page.Resources.ByType "image").GetMatch (printf "**/%s" $src) -}}
 	{{ $resized := . }}
 	{{ if (gt .Width $imgwidth) }}
 		{{ if hugo.IsExtended }}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -8,7 +8,7 @@
 <!-- get actual filename -->
 {{- $src = path.Base $src -}}
 <!-- check if it exists as a page resource -->
-{{- with (.Page.Resources.ByType "image").GetMatch (printf "**%s" $src) -}}
+{{- with (.Page.Resources.ByType "image").GetMatch (printf "%s" $src) -}}
 	{{ $resized := . }}
 	{{ if (gt .Width $imgwidth) }}
 		{{ if hugo.IsExtended }}


### PR DESCRIPTION
# Description

Use exact match to decide which image file should be rendered in `render-image.html` layout.

(Thank you for this great elegant Hugo theme...!)

Fixes #34 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
